### PR TITLE
Feat: Implement adaptive puzzle timeout

### DIFF
--- a/SeirChain/core/consensus/proof_of_fractal.rs
+++ b/SeirChain/core/consensus/proof_of_fractal.rs
@@ -60,7 +60,8 @@ impl ProofOfFractal {
     pub fn solve_puzzle(&self, data: &[u8]) -> bool {
         let mut rng = OsRng;
         let start_time = std::time::Instant::now();
-        let timeout = std::time::Duration::from_secs(60); // 1 minute timeout
+        let timeout_secs = (*self.difficulty.lock().unwrap() as u64).pow(2).max(30).min(300);
+        let timeout = std::time::Duration::from_secs(timeout_secs);
 
         loop {
             if start_time.elapsed() > timeout {


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement an adaptive timeout for the puzzle-solving mechanism in the SeirChain consensus algorithm, replacing the fixed 60-second timeout with a dynamic timeout based on the square of the difficulty level, bounded between 30 and 300 seconds.

### Why are these changes being made?

These changes aim to improve the efficiency of the proof-of-fractal consensus process by adjusting the puzzle-solving timeout according to the difficulty level, ensuring it is stringent enough to be challenging but not so long as to hinder system performance. This approach allows for more adaptive and responsive timeout management based on network conditions and computational demand.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->